### PR TITLE
showメソッドの実装

### DIFF
--- a/handler/user_handler.go
+++ b/handler/user_handler.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 
+	"github.com/gorilla/mux"
 	"github.com/koyo-miyamura/go-api-practice/model"
 )
 
@@ -20,10 +21,10 @@ func NewUserHandler(m model.UserModel) *UserHandler {
 }
 
 // NewUserServer create user model's handler
-func (h *UserHandler) NewUserServer() *http.ServeMux {
-	server := http.NewServeMux()
-	server.HandleFunc("/users", h.Index)
-	return server
+func (h *UserHandler) NewUserServer() *mux.Router {
+	router := mux.NewRouter().StrictSlash(true)
+	router.HandleFunc("/users", h.Index)
+	return router
 }
 
 // Index is user model's index

--- a/handler/user_handler.go
+++ b/handler/user_handler.go
@@ -4,9 +4,11 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
+	"strconv"
 
 	"github.com/gorilla/mux"
 	"github.com/koyo-miyamura/go-api-practice/model"
+	"github.com/pkg/errors"
 )
 
 // UserHandler はどのmodelを使うかを保持します
@@ -23,7 +25,8 @@ func NewUserHandler(m model.UserModel) *UserHandler {
 // NewUserServer create user model's handler
 func (h *UserHandler) NewUserServer() *mux.Router {
 	router := mux.NewRouter().StrictSlash(true)
-	router.HandleFunc("/users", h.Index)
+	router.HandleFunc("/users", h.Index).Methods("GET")
+	router.HandleFunc("/users/{id:[0-9]+}", h.Show).Methods("GET")
 	return router
 }
 
@@ -34,6 +37,31 @@ func (h *UserHandler) Index(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	res := h.model.Index()
+
+	result, err := json.Marshal(res)
+	if err != nil {
+		log.Println(err.Error())
+	}
+	_, err = w.Write(result)
+	if err != nil {
+		log.Println(err.Error())
+	}
+}
+
+// Show is user model's show
+func (h *UserHandler) Show(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	idStr := vars["id"]
+	id, err := strconv.ParseUint(idStr, 10, 64)
+	if err != nil {
+		log.Panicln(errors.Wrapf(err, "error parse uint:%v", idStr))
+	}
+
+	log.Printf("/users/%d handled", id)
+
+	w.Header().Set("Content-Type", "application/json")
+
+	res := h.model.Show(id)
 
 	result, err := json.Marshal(res)
 	if err != nil {

--- a/handler/user_handler.go
+++ b/handler/user_handler.go
@@ -61,7 +61,12 @@ func (h *UserHandler) Show(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 
-	res := h.model.Show(id)
+	res, err := h.model.Show(id)
+	if err != nil {
+		log.Println(err)
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
 
 	result, err := json.Marshal(res)
 	if err != nil {

--- a/handler/user_handler_test.go
+++ b/handler/user_handler_test.go
@@ -51,3 +51,51 @@ func TestIndex(t *testing.T) {
 		t.Fatalf("responce got %v, want %v", got, want)
 	}
 }
+
+func TestShow(t *testing.T) {
+	db, err := util.TestDbNew()
+	if err != nil {
+		t.Fatal(err, "DB接続できませんでした")
+	}
+	defer util.TestDbClose(db)
+
+	req := httptest.NewRequest(http.MethodGet, "/users/1", nil)
+	w := httptest.NewRecorder()
+
+	want := &model.ShowResponse{
+		User: &schema.User{
+			ID:   1,
+			Name: "hoge",
+		},
+	}
+
+	um := stub.NewUserModel()
+	um.ShowStub = func(id uint64) *model.ShowResponse {
+		if id == 1 {
+			return want
+		}
+		return nil
+	}
+	h := NewUserHandler(um)
+	r := h.NewUserServer()
+	r.ServeHTTP(w, req) // gorilla/muxがパラメータ取り出すにはこれを経由させる必要がある
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status code %v", w.Code)
+	}
+
+	got := &model.ShowResponse{}
+	util.JSONRead(w, got)
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("responce got %v, want %v", got, want)
+	}
+
+	// // Fail
+	// req = httptest.NewRequest(http.MethodGet, "/users/10000", nil)
+	// h.Show(w, req)
+
+	// if w.Code != http.StatusNotFound {
+	// 	t.Fatalf("status code %v", w.Code)
+	// }
+}

--- a/handler/user_handler_test.go
+++ b/handler/user_handler_test.go
@@ -38,7 +38,8 @@ func TestIndex(t *testing.T) {
 		return want
 	}
 	h := NewUserHandler(um)
-	h.Index(w, req)
+	r := h.NewUserServer()
+	r.ServeHTTP(w, req)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("status code %v", w.Code)

--- a/model/stub/user_stub.go
+++ b/model/stub/user_stub.go
@@ -7,17 +7,26 @@ import (
 // UserModel is xxx
 type UserModel struct {
 	IndexStub func() *model.IndexResponse
+	ShowStub  func(id uint64) *model.ShowResponse
 }
 
-// Index return stub of UserModel
+// Index return stub of UserModel.Index
 func (u *UserModel) Index() *model.IndexResponse {
 	return u.IndexStub()
+}
+
+// Show return stub of UserModel.Show
+func (u *UserModel) Show(id uint64) *model.ShowResponse {
+	return u.ShowStub(id)
 }
 
 // NewUserModel returns stub of UserModel
 func NewUserModel() *UserModel {
 	return &UserModel{
 		IndexStub: func() *model.IndexResponse {
+			return nil
+		},
+		ShowStub: func(id uint64) *model.ShowResponse {
 			return nil
 		},
 	}

--- a/model/stub/user_stub.go
+++ b/model/stub/user_stub.go
@@ -1,13 +1,15 @@
 package stub
 
 import (
+	"errors"
+
 	"github.com/koyo-miyamura/go-api-practice/model"
 )
 
 // UserModel is xxx
 type UserModel struct {
 	IndexStub func() *model.IndexResponse
-	ShowStub  func(id uint64) *model.ShowResponse
+	ShowStub  func(id uint64) (*model.ShowResponse, error)
 }
 
 // Index return stub of UserModel.Index
@@ -16,7 +18,7 @@ func (u *UserModel) Index() *model.IndexResponse {
 }
 
 // Show return stub of UserModel.Show
-func (u *UserModel) Show(id uint64) *model.ShowResponse {
+func (u *UserModel) Show(id uint64) (*model.ShowResponse, error) {
 	return u.ShowStub(id)
 }
 
@@ -26,8 +28,8 @@ func NewUserModel() *UserModel {
 		IndexStub: func() *model.IndexResponse {
 			return nil
 		},
-		ShowStub: func(id uint64) *model.ShowResponse {
-			return nil
+		ShowStub: func(id uint64) (*model.ShowResponse, error) {
+			return nil, errors.New("not implementation")
 		},
 	}
 }

--- a/model/user.go
+++ b/model/user.go
@@ -8,6 +8,7 @@ import (
 // UserModel is interface of UserModel
 type UserModel interface {
 	Index() *IndexResponse
+	Show(id uint64) *ShowResponse
 }
 
 // userModel is model struct of user
@@ -30,4 +31,16 @@ func (u *userModel) Index() *IndexResponse {
 	users := []*schema.User{}
 	u.db.Find(&users)
 	return &IndexResponse{Users: users}
+}
+
+// ShowResponse is response format for Show
+type ShowResponse struct {
+	User *schema.User `json:"user"`
+}
+
+// Show returns all users
+func (u *userModel) Show(id uint64) *ShowResponse {
+	user := &schema.User{}
+	u.db.Find(&user, id)
+	return &ShowResponse{User: user}
 }

--- a/model/user.go
+++ b/model/user.go
@@ -1,6 +1,8 @@
 package model
 
 import (
+	"errors"
+
 	"github.com/jinzhu/gorm"
 	"github.com/koyo-miyamura/go-api-practice/schema"
 )
@@ -8,7 +10,7 @@ import (
 // UserModel is interface of UserModel
 type UserModel interface {
 	Index() *IndexResponse
-	Show(id uint64) *ShowResponse
+	Show(id uint64) (*ShowResponse, error)
 }
 
 // userModel is model struct of user
@@ -39,8 +41,10 @@ type ShowResponse struct {
 }
 
 // Show returns all users
-func (u *userModel) Show(id uint64) *ShowResponse {
+func (u *userModel) Show(id uint64) (*ShowResponse, error) {
 	user := &schema.User{}
-	u.db.Find(&user, id)
-	return &ShowResponse{User: user}
+	if err := u.db.Find(&user, id).Error; err != nil {
+		return nil, errors.New("error find user")
+	}
+	return &ShowResponse{User: user}, nil
 }

--- a/model/user_test.go
+++ b/model/user_test.go
@@ -54,7 +54,10 @@ func TestShow(t *testing.T) {
 	db.Create(&user)
 
 	um := NewUserModel(db)
-	res := um.Show(1)
+	res, err := um.Show(1)
+	if err != nil {
+		t.Errorf("error Show method %v", err)
+	}
 
 	got := res.User
 	want := user

--- a/model/user_test.go
+++ b/model/user_test.go
@@ -39,3 +39,31 @@ func TestIndex(t *testing.T) {
 		}
 	}
 }
+
+func TestShow(t *testing.T) {
+	db, err := util.TestDbNew()
+	if err != nil {
+		t.Fatal(err, "DB接続できませんでした")
+	}
+	defer util.TestDbClose(db)
+
+	user := schema.User{
+		ID:   1,
+		Name: "hoge",
+	}
+	db.Create(&user)
+
+	um := NewUserModel(db)
+	res := um.Show(1)
+
+	got := res.User
+	want := user
+
+	if want.ID != got.ID {
+		t.Errorf("user ID got %v, want %v", got.ID, want.ID)
+	}
+
+	if want.Name != got.Name {
+		t.Errorf("user name got %v, want %v", got.Name, want.Name)
+	}
+}


### PR DESCRIPTION
gorilla/muxの導入
https://github.com/gorilla/mux

### テストメモ
```go
req := httptest.NewRequest(http.MethodGet, "/users", nil)
w := httptest.NewRecorder()
h := NewUserHandler(um)
h.Index(w, req)
```
こういうテストしてしまうとIndexメソッドそのもののテストはできるが、**ルーティング部分はテストされない**
つまり、req := httptest.NewRequest(http.MethodGet, "/users", nil)のパス部分`/users`を適当に変更してもルーティングできてしまう

```go
	h := NewUserHandler(um)
	r := h.NewUserServer()
	r.ServeHTTP(w, req) // gorilla/muxがパラメータ取り出すにはこれを経由させる必要がある
```
なので上記のように[router.ServeHTTP](http://www.gorillatoolkit.org/pkg/mux#Router.ServeHTTP)を呼ばないといけない

ちなみに実装は以下だが、このメソッドを通過させることで
```go
vars := mux.Vars(r)
```
のように値を取り出すことができるようになる
https://github.com/gorilla/mux/blob/master/mux.go#L121

### 現状
現状学習用なのでザックリ実装しているが、もっとちゃんとやろうとすると色々考えられる
* エラーの性質によってBadRequestやInternalServerErrorを返す
肥大化していきがちなので、しっかりパッケージに分ける必要があるかなと思われる